### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,11 @@
  .mw-xl {
    max-width: 1200px;
  }
+
+ .alert-notice {
+   @extend .alert-success;
+ }
+
+ .alert-alert {
+   @extend .alert-danger;
+ }

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
      <%= render "layouts/header" %>
    </header>
    <main>
+     <%= render "layouts/flash" %>
      <%# max_width メソッドは application_helper.rb に記載 %>
      <div class="base-container <%= max_width %>">
        <%= yield %>


### PR DESCRIPTION
close #12 

## 実装内容
- フラッシュの表示機能
  - 横幅一杯にする（mainタグの開始タグすぐ下）
  - 部分テンプレート `app/views/layouts/_flash.html.erb` を作成して読み込むようにする
- フラッシュの背景色を設定
  - Bootstrapに用意されているものを利用
  - notice は alert-info か alert-success, alert は alert-danger とした
  
## 確認内容
ログイン時・ログアウト時にフラッシュが表示されることを確認

## 参考資料（必要があれば）
- メッセージ投稿アプリ（その3・Bootstrap）
  - [やんばるエキスパート教材](https://www.yanbaru-code.com/texts/271)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
