### PR TITLE
navbarを実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,37 +3,41 @@
  *= require_self
  */
 
- @import "bootstrap/scss/bootstrap";
+@import 'bootstrap/scss/bootstrap';
 
- /* 全体 */
+/* 全体 */
 
- .base-container {
-   margin: 0 auto;
-   padding: 1rem;
- }
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
 
- /* max-width */
+body {
+  padding-top: 70px;
+}
 
- .mw-sm {
-   max-width: 576px;
- }
+/* max-width */
 
- .mw-md {
-   max-width: 768px;
- }
+.mw-sm {
+  max-width: 576px;
+}
 
- .mw-lg {
-   max-width: 992px;
- }
+.mw-md {
+  max-width: 768px;
+}
 
- .mw-xl {
-   max-width: 1200px;
- }
+.mw-lg {
+  max-width: 992px;
+}
 
- .alert-notice {
-   @extend .alert-success;
- }
+.mw-xl {
+  max-width: 1200px;
+}
 
- .alert-alert {
-   @extend .alert-danger;
- }
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,9 +1,35 @@
-<% if user_signed_in? %>
-  <%# ログイン時 %>
-  <%= link_to "アカウント編集", edit_user_registration_path %>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-<% else %>
-  <%# 非ログイン時 %>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <%= link_to "ログイン", new_user_session_path %>
-<% end %>
+<nav class="navbar navbar-expand-md navbar-dark bg-primary fixed-top">
+  <a class="navbar-brand" href="/">
+    <%= image_tag("yanbaru_expert_logo.png") %>
+  </a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto ml-3">
+      <li class="nav-item active dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> Ruby </a>
+        <div class="dropdown-menu" aria-labellendby="navbarDropdown">
+          <%= link_to "Ruby/Railsテキスト教材", "/texts", class: "dropdown-item" %>
+          <%= link_to "Ruby/Rails動画教材", "/movies", class: "dropdown-item" %>
+        </div>
+      </li>
+      <li class="nav-item active dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> PHP </a>
+        <div class="dropdown-menu" aria-labellendby="navbarDropdown">
+          <%= link_to "PHPテキスト教材", texts_path(genre: "php"), class: "dropdown-item" %>
+          <%= link_to "PHP動画教材", movies_path(genre: "php"), class: "dropdown-item" %>
+        </div>
+      </li>
+      <% if user_signed_in? %>
+        <%# ログイン時 %>
+        <li><%= link_to "アカウント編集", edit_user_registration_path, class: "nav-link active" %></li>
+        <li><%= link_to "ログアウト", destroy_user_session_path, class: "nav-link active", method: :delete, data: { confirm: "ログアウトしますか？" } %></li>
+      <% else %>
+        <%# 非ログイン時 %>
+        <li><%= link_to "新規登録", new_user_registration_path, class: "nav-link active" %></li>
+        <li><%= link_to "ログイン", new_user_session_path, class: "nav-link active" %></li>
+      <% end %>
+    </ul>
+  </div>
+</nav>


### PR DESCRIPTION
close #11

## 実装内容

- Bootstrap のナビバーを利用して，ナビバーを作成
  -  .fixed-top を使用して上に固定すること
  - ロゴは app/assets/images/yanbaru_expert_logo.png を利用
  - リンクは link_to ヘルパーメソッドを使用
  - PHPテキスト教材のパスは texts_path(genre: "php"), 動画教材は movies_path(genre: "php") とすること
  - md サイズ未満で「ハンバーガーメニュー」に切り替わる
  - コンテンツがヘッダーに隠れないよう調整

## 確認内容
- ローカルで影響するURLでの動作確認
- mdサイズ未満でのハンバーガーメニューでの動作確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
