### PR TITLE
enum_helpを用いて、表示名の設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-bootstrap-views", "~> 1.0"
 gem "devise-i18n"
+gem "enum_help"
 gem "jbuilder", "~> 2.7"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     devise-bootstrap-views (1.1.0)
     devise-i18n (1.10.0)
       devise (>= 4.8.0)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.3)
     globalid (0.5.2)
@@ -246,6 +248,7 @@ DEPENDENCIES
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,12 @@
+ja:
+  enums:
+   text: &genres
+      genre:
+        invisible: "非表示"
+        basic: "Basic"
+        git: "Git"
+        ruby: "Ruby"
+        rails: "Ruby on Rails"                      
+        php: "PHP"
+   movie:
+     *genres


### PR DESCRIPTION

close #10 

## 実装内容

- `enum-help` を追加
- `texts`, `movies` テーブルの `genre` に対応する表示名 `config/locales/enums.ja.yml` に追加
  - YAML の アンカー（`&`）, エイリアス（`*`）を利用して重複を回避。
  - 「表示名」の設定は，「確認内容」の箇所を参考にしました。

## 確認内容

- 以下を実行し，教材データが入っていることを確認

```
rails c

# Railsコンソール起動後
Text.genres_i18n
#=> {"invisible"=>"非表示", "basic"=>"Basic", "git"=>"Git", "ruby"=>"Ruby", "rails"=>"Ruby on Rails", "php"=>"PHP"}

Movie.genres_i18n
#=> {"invisible"=>"非表示", "basic"=>"Basic", "git"=>"Git", "ruby"=>"Ruby", "rails"=>"Ruby on Rails", "php"=>"PHP"}
```
## 参考資料（必要があれば）

- [【やんばるエキスパート教材】列挙型（enum）とセレクトボックス](https://www.yanbaru-code.com/texts/351)

- アンカーとエイリアスについて
  - [YAML入門](http://cloudcafe.tech/?p=1776)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

