### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,12 @@
+iframe{
+  width: 100%;
+  height: 100%;
+}
+
+.movie-header{
+  height: 190px;
+}
+
+.movie-body{
+  height: 190px;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,10 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+    )
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,5 @@
 class Movie < ApplicationRecord
+  RAILS_GENRE_LIST = %w[basic git ruby rails]
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,15 @@
+<div class="col-12 col-md-6 col-lg-4">
+  <div class="card border-dark mb-3">
+    <div class="card-header movie-header p-0">
+      <%= embed_youtube(movie.url) %>
+    </div>
+    <div class="card-body text-dark movie-body">
+      <p>
+        <object>
+          <a class="btn btn-secondary btn-block">読破済みにする</a>
+        </object>
+      </p>
+      <p class="card-text mt-3">Lv.<%= "#{movie_counter}".to_i + 1%>：<%= movie.title %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,12 @@
+<div class="container mw-xl">
+  <div class="contents-title text-center">
+    <h1>Ruby/Rails 動画</h1>
+  </div>
+  <div class="container-fluid">
+    <div class="row">
+      <%= render partial: "movie", collection: @movies %>
+    </div>
+  </div>
+</div>
+
 


### PR DESCRIPTION
close #15 

## 実装内容
- app/models/movie.rb に次を定義
  - RAILS_GENRE_LIST = %w[basic git ruby rails]
- Rails動画教材の一覧ページを作成
  - 表示するジャンルは Movie::RAILS_GENRE_LIST に制限
  - Bootstrapの Cards や Grid System を用いて下図のようなスタイルにする
  - each を使わず「コレクションをレンダリング」を利用
  - 各動画にレベル表示
  - カードの下側部分に height を指定
  - 動画教材ページでしか利用しないスタイルは app/assets/stylesheets/movies.scss を作成して書き込む
  - 「視聴済みボタン」はボタンの配置のみ

## 確認内容
 - レスポンシブ対応
 - カードの高さが一定
 - PHPの動画教材が表示されていない

## 参考資料（必要があれば）
- [やんばるエキスパートYouTube動画の投稿](https://www.yanbaru-code.com/texts/349)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
