### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.genre_list(params[:genre])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_title
+    if params[:genre] == "php"
+      "PHP"
+    else
+      "Ruby/Rails"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,6 @@
 class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails]
+  PHP_GENRE_LIST = %w[php]
   with_options presence: true do
     validates :genre
     validates :title
@@ -13,4 +14,12 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  def self.genre_list(genre)
+    if genre == "php"
+      where(genre: Movie::PHP_GENRE_LIST)
+    else
+      where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mw-xl">
   <div class="contents-title text-center">
-    <h1>Ruby/Rails 動画</h1>
+    <h1><%= movie_title %></h1>
   </div>
   <div class="container-fluid">
     <div class="row">
@@ -8,5 +8,3 @@
     </div>
   </div>
 </div>
-
-


### PR DESCRIPTION
close #18 

## 実装内容
- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
  - ```PHP動画教材``` のリンクをクリックした際のクエリパラメータ ```?genre=php``` を利用
  - モデルにクラスメソッドを作成して対応
- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする
  - ```app/helpers/application_helper.rb``` にメソッドを作成して対応


## 確認内容
- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ ```?genre=php``` を ```php``` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行


