### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.genre_categorize(params[:genre])
   end
 
   def show; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def text_title
+    if params[:genre] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
+
   def max_width
     if controller_name == "texts" && action_name == "show"
       "mw-md"

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,11 @@
 class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails]
+  PHP_GENRE_LIST = %w[php]
+
+  def self.genre_categorize(genre)
+    genre == "php" ? where(genre: PHP_GENRE_LIST) : where(genre: RAILS_GENRE_LIST)
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,7 +1,4 @@
-<h1 class="text-center mt-2 mb-4">
-    Ruby/Rails
-  <br class="d-sm-none">
-     テキスト教材
+<h1 class="text-center mt-2 mb-4"><%= text_title %><br class="d-sm-none">
 </h1>
 <div class="row">
   <%= render partial: "text", collection: @texts %>


### PR DESCRIPTION
close #20 

## 実装内容
- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
  - PHPテキスト教材 のリンクをクリックした際のクエリパラメータ ?genre=php を利用
  - モデルにクラスメソッドを作成して対応
- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする
  - app/helpers/application_helper.rb にメソッドを利用 

## 確認内容
- Ruby/Railsテキスト教材」に「PHPテキスト教材」が含まれていないことを確認
- 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認
- クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行