### PR TITLE
動画教材の読破済み機能を追加

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   PER_PAGE = 12
   def index
-    @movies = Movie.genre_list(params[:genre]).page(params[:page]).per(PER_PAGE)
+    @movies = Movie.includes(:watch_progresses).order(:created_at).genre_list(params[:genre]).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,11 @@
+class WatchProgressesController < ApplicationController
+  def create
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.create!(movie_id: @movie.id)
+  end
+
+  def destroy
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,11 +15,17 @@ class Movie < ApplicationRecord
     php: 5
   }
 
+  has_many :watch_progresses, dependent: :destroy
+
   def self.genre_list(genre)
     if genre == "php"
       where(genre: Movie::PHP_GENRE_LIST)
     else
       where(genre: Movie::RAILS_GENRE_LIST)
     end
+  end
+
+  def watch_progressed_by?(user)
+    watch_progresses.any? { |watch| watch.user_id == user.id }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   has_many :read_progresses
   has_many :read_progressed_texts, through: :read_progresses, source: :text
+  has_many :watch_progresses, dependent: :destroy
+  has_many :watch_progressed_texts, through: :watch_progresses, source: :text
   def self.guest
     find_or_create_by!(email: "test@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,9 @@
+class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+
+  validates :user_id, uniqueness: {
+    scope: :movie_id,
+    message: "は同じ動画教材を2回以上視聴済みにはできません"
+  }
+end

--- a/app/views/movies/_diswatchprogress.html.erb
+++ b/app/views/movies/_diswatchprogress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), method: :post, class: "btn btn-secondary btn-block", remote: true%>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -4,9 +4,13 @@
       <%= embed_youtube(movie.url) %>
     </div>
     <div class="card-body text-dark movie-body">
-      <p>
+      <p id="movie-<%= movie.id %>">
         <object>
-          <a class="btn btn-secondary btn-block">読破済みにする</a>
+          <% if movie.watch_progressed_by?(current_user) %>
+            <%= render "watchprogress", movie: movie %>
+          <% else %>
+            <%= render "diswatchprogress", movie: movie %>
+          <% end %>
         </object>
       </p>
       <p class="card-text mt-3">Lv.<%= "#{movie_counter}".to_i + @movies.offset_value + 1%>：<%= movie.title %></p>

--- a/app/views/movies/_watchprogress.html.erb
+++ b/app/views/movies/_watchprogress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie), method: :delete, class: "btn btn-primary btn-block", remote: true %>

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/watchprogress", movie: @movie) %>'

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/diswatchprogress", movie: @movie) %>'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   resources :texts, only: [:index, :show] do
     resource :read_progresses, only: [:create, :destroy]
   end
-  resources :movies, only: [:index]
+  resources :movies, only: [:index] do
+    resource :watch_progresses, only: [:create, :destroy]
+  end
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end

--- a/db/migrate/20211009073359_create_watch_progresses.rb
+++ b/db/migrate/20211009073359_create_watch_progresses.rb
@@ -1,0 +1,11 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_03_062317) do
+ActiveRecord::Schema.define(version: 2021_10_09_073359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,18 @@ ActiveRecord::Schema.define(version: 2021_10_03_062317) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
   add_foreign_key "read_progresses", "texts"
   add_foreign_key "read_progresses", "users"
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #23

## 実装内容
- 視聴済み機能に使用する ```WatchProgress```モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる（User と Movie の関連付けは使用しないので入れなくてもOK）
- 動画教材一覧ページに視聴済み機能を実装
  - 非同期で処理できるようにすること


## 確認内容
``` 
rails c -s

# Railsコンソール起動後
user = User.first
movie, movie2 = Movie.limit(2)
WatchProgress.delete_all

user.watch_progresses.create!(movie_id: movie.id)
user.watch_progresses.create!(movie_id: movie2.id)

WatchProgress.count
#=> 2

movie.watch_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じ動画教材を2回以上視聴済みにはできません

WatchProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, 動画教材を入力してください
```

## 参考資料

  - [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
