### PR TITLE
Release/1.0

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bin/rails db:migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
close #24 

## 実装内容

- ブランチ名は `release/1.0` とすること

- Herokuにプッシュした際に自動でマイグレーションを行う設定を追加

```zsh
echo "release: bin/rails db:migrate" > Procfile
```

- Heroku アプリを作成
  - ステージング環境は作成しなくてもOK
  - 自動デプロイ設定は，権限の都合上対応が難しいため，設定しない方向でお願いします

- コミットした上で Heroku にデプロイし，初期データを投入
  - エラーが出た場合は対応

```zdh
git push heroku HEAD:main
heroku run rails db:seed
```

- 動作確認を行い，異常を発見した場合は対応

- 問題が解消された時点でプルリクを2つ出す
  - マージ先の指定は `develop` ブランチと `main` ブランチとする


## 参考資料

[Heroku上で背景画像が表示されないけどなんなんこれ](https://qiita.com/___fff_/items/fa15f358beba2b9389da)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
- [x] herokuアプリでの動作確認済み


## 備考
テキスト教材一覧の画像が表示されなかったので、
[Heroku上で背景画像が表示されないけどなんなんこれ](https://qiita.com/___fff_/items/fa15f358beba2b9389da)
を参考にして、`config/environments/production.rb`の
config.assets.compile = false
を、
config.assets.compile = true
に修正